### PR TITLE
Update xION stake rewards to have adaptable xION stake rewards

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2066,9 +2066,9 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue, int nMasternodeCou
             ret = blockValue * .50;
             // staking reward xION on zerocoin staking
             if (isXIONStake) {
-                if (nHeight > 900000 && nHeight <= 1013538) {    // 568622+1440=570062   1012098+1440=1013538
-                    ret = blockValue - floor(blockValue/COIN/2) * COIN;  // 11.5 - floor(11.5/2) = 11.5 - 5 = 6.5
-                } else if (nHeight > 1013538 && nHeight <= 4167138) {    //
+                if (nHeight > Params().Zerocoin_Block_V2_Start() && nHeight <= 1013538) {
+                    ret = blockValue - floor(blockValue/COIN/2) * COIN;  // 17 - floor(17/2) = 17 - 8 = 9
+                } else if (nHeight > 1013538 && nHeight <= 4167138) {    // 11.5 - floor(11.5/2) = 11.5 - 5 = 6.5
                     ret = blockValue - floor(blockValue/COIN/2) * COIN;  // 5.75 - floor(5.75/2) = 5.75 - 2 = 3.75
                 } else if (nHeight > 4167138 && nHeight <= 4692738) {    //
                     ret = 1.0 * COIN;                                    // (1.90-0.9)*0.5=0.5=>1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2067,11 +2067,11 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue, int nMasternodeCou
             // staking reward xION on zerocoin staking
             if (isXIONStake) {
                 if (nHeight > 900000 && nHeight <= 1013538) {    // 568622+1440=570062   1012098+1440=1013538
-                    ret = (blockValue - 1.5) * .50;                      // (11.5-1.5)*0.5=5
+                    ret = blockValue - floor(blockValue/COIN/2) * COIN;  // 11.5 - floor(11.5/2) = 11.5 - 5 = 6.5
                 } else if (nHeight > 1013538 && nHeight <= 4167138) {    //
-                    ret = (blockValue - 1.75) * .50;                     // (5.75-1.75)*0.5=2
+                    ret = blockValue - floor(blockValue/COIN/2) * COIN;  // 5.75 - floor(5.75/2) = 5.75 - 2 = 3.75
                 } else if (nHeight > 4167138 && nHeight <= 4692738) {    //
-                    ret = 0.90 * COIN;                                   // (1.90-0.9)*0.5=0.5=>1
+                    ret = 1.0 * COIN;                                    // (1.90-0.9)*0.5=0.5=>1
                 } else if (nHeight > 3677390 && Params().NetworkID() == CBaseChainParams::TESTNET) {
                     ret = blockValue;
                 } else if (nHeight > 3677390 && Params().NetworkID() == CBaseChainParams::REGTEST) {

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -135,10 +135,13 @@ bool CXIonStake::CreateTxOuts(CWallet* pwallet, vector<CTxOut>& vout, CAmount nT
     if (!pwallet->DatabaseMint(dMint))
         return error("%s: failed to database the staked xION", __func__);
 
-    for (unsigned int i = 0; i < 3; i++) {
+    CAmount toMint = (nTotal - this->GetValue()) / 2;
+    while (toMint >= 1 * COIN) {
+        libzerocoin::CoinDenomination denomination = libzerocoin::AmountToClosestDenomination(toMint, toMint);
+
         CTxOut out;
         CDeterministicMint dMintReward;
-        if (!pwallet->CreateXIONOutPut(libzerocoin::CoinDenomination::ZQ_ONE, out, dMintReward))
+        if (!pwallet->CreateXIONOutPut(denomination, out, dMintReward))
             return error("%s: failed to create xION output", __func__);
         vout.emplace_back(out);
 


### PR DESCRIPTION
This addresses https://github.com/ioncoincore/ion/issues/37
TODO: stake rewards for lower block heights than the 11.5 ION period