### PR TITLE
Change snapcraft to use gXX-4.8 for arm32 builds (Issue 115)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,14 +90,10 @@ parts:
       ## Patch - Fix Bug extracting sources without ownership
       sed -i 's/tar --strip-components/tar --no-same-owner --strip-components/' $SNAPCRAFT_PART_BUILD/depends/funcs.mk
       ## make gcc-4.8  the default compiler
-      #/usr/sbin/update-alternatives --install /usr/bin/gcc gcc \
-      #/usr/bin/gcc-4.8 100
-      #/usr/sbin/update-alternatives --install /usr/bin/g++ g++ \
-      #/usr/bin/g++-4.8 100
-      /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
-      arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100
-      /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
-      arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
+      /usr/sbin/update-alternatives --install /usr/bin/gcc gcc \
+      /usr/bin/gcc-4.8 100
+      /usr/sbin/update-alternatives --install /usr/bin/g++ g++ \
+      /usr/bin/g++-4.8 100
       # Build Dependencies
       echo "START BUILDING FOR $SNAPCRAFT_ARCH_TRIPLET architecture"
       cd $SNAPCRAFT_PART_BUILD/depends
@@ -129,10 +125,8 @@ parts:
     build-packages:
       - curl
       - wget
-      - g++
-      - gcc
-      - gcc-4.8-arm-linux-gnueabihf
-      - g++-4.8-arm-linux-gnueabihf
+      - gcc-4.8
+      - g++-4.8
       - make
       - autoconf
       - automake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2018-2019 The Ion developers
 
-name: ioncore
+name: ckti-ion
 version: 3.1.99
 summary:   gaming related peer-to-peer network based digital currency
 description: |
@@ -89,6 +89,15 @@ parts:
       git apply $SNAPCRAFT_STAGE/fix-bdb-tmp-folder.patch
       ## Patch - Fix Bug extracting sources without ownership
       sed -i 's/tar --strip-components/tar --no-same-owner --strip-components/' $SNAPCRAFT_PART_BUILD/depends/funcs.mk
+      ## make gcc-4.8  the default compiler
+      #/usr/sbin/update-alternatives --install /usr/bin/gcc gcc \
+      #/usr/bin/gcc-4.8 100
+      #/usr/sbin/update-alternatives --install /usr/bin/g++ g++ \
+      #/usr/bin/g++-4.8 100
+      /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
+      arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100
+      /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
+      arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
       # Build Dependencies
       echo "START BUILDING FOR $SNAPCRAFT_ARCH_TRIPLET architecture"
       cd $SNAPCRAFT_PART_BUILD/depends
@@ -122,6 +131,8 @@ parts:
       - wget
       - g++
       - gcc
+      - gcc-4.8-arm-linux-gnueabihf
+      - g++-4.8-arm-linux-gnueabihf
       - make
       - autoconf
       - automake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,12 +97,16 @@ parts:
       make download-linux
       if [ $SNAPCRAFT_ARCH_TRIPLET = "i386-linux-gnu" ]
       then
-        make -j10 HOST=i686-linux-gnu
+        make -j8 HOST=i686-linux-gnu
       elif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
       then
-        make gcc=gcc-4.8 g++=g++-4.8 -j10 HOST=$SNAPCRAFT_ARCH_TRIPLET
+        update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
+        arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100
+        update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
+        arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
+        make -j8 HOST=$SNAPCRAFT_ARCH_TRIPLET
       else
-        make -j10 HOST=$SNAPCRAFT_ARCH_TRIPLET
+        make -j8 HOST=$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Configure Ion Core
       cd $SNAPCRAFT_PART_BUILD
@@ -112,23 +116,16 @@ parts:
         ./configure --prefix=`pwd`/depends/i686-linux-gnu
       elif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
       then
-        /usr/bin/apt install gcc-4.8 g++-4.8
-        /usr/sbin/update-alternatives --install /usr/bin/gcc \
-        gcc /usr/bin/gcc-4.8 100\
-        /usr/sbin/update-alternatives --install /usr/bin/g++ \
-        g++ /usr/bin/g++-4.8 100
-        ./configure gcc=gcc-4.8 gxx+=g++4.8 \
-        --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
+        update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
+        arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100
+        update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
+        arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
+        ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       else
         ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Compile Ion Core
-      if [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
-      then
-        make -j10 gcc=gcc-4.8 gxx=g++-4.8 HOST=$SNAPCRAFT_ARCH_TRIPLET
-      else
-        make -j10
-      fi
+      make -j8 
       # Install Ion Core
       make install prefix=$SNAPCRAFT_PART_INSTALL
       # print in log which files are installed
@@ -139,6 +136,8 @@ parts:
       - wget
       - gcc
       - g++
+      - gcc-4.8
+      - g++-4.8
       - make
       - autoconf
       - automake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,9 +107,9 @@ parts:
       if [ $SNAPCRAFT_ARCH_TRIPLET = "i386-linux-gnu" ]
       then
         ./configure --prefix=`pwd`/depends/i686-linux-gnu
-      elsif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
+      elif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
       then
-        apt install arm-linux-gnueabihf-gcc-4.8 arm-linux-gnueabihf-g++-4.8
+        /usr/bin/apt install arm-linux-gnueabihf-gcc-4.8 arm-linux-gnueabihf-g++-4.8
         /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
         arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100\
         /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,6 +98,9 @@ parts:
       if [ $SNAPCRAFT_ARCH_TRIPLET = "i386-linux-gnu" ]
       then
         make -j10 HOST=i686-linux-gnu
+      elif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
+      then
+        make gcc=gcc-4.8 g++=g++-4.8 -j10 HOST=$SNAPCRAFT_ARCH_TRIPLET
       else
         make -j10 HOST=$SNAPCRAFT_ARCH_TRIPLET
       fi
@@ -109,17 +112,23 @@ parts:
         ./configure --prefix=`pwd`/depends/i686-linux-gnu
       elif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
       then
-        /usr/bin/apt install arm-linux-gnueabihf-gcc-4.8 arm-linux-gnueabihf-g++-4.8
-        /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
-        arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100\
-        /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
-        arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
-        ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
+        /usr/bin/apt install gcc-4.8 g++-4.8
+        /usr/sbin/update-alternatives --install /usr/bin/gcc \
+        gcc /usr/bin/gcc-4.8 100\
+        /usr/sbin/update-alternatives --install /usr/bin/g++ \
+        g++ /usr/bin/g++-4.8 100
+        ./configure gcc=gcc-4.8 gxx+=g++4.8 \
+        --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       else
         ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Compile Ion Core
-      make -j10
+      if [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
+      then
+        make -j10 gcc=gcc-4.8 gxx=g++-4.8 HOST=$SNAPCRAFT_ARCH_TRIPLET
+      else
+        make -j10
+      fi
       # Install Ion Core
       make install prefix=$SNAPCRAFT_PART_INSTALL
       # print in log which files are installed

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2018-2019 The Ion developers
 
-name: ckti-ion
+name: ioncore
 version: 3.1.99
 summary:   gaming related peer-to-peer network based digital currency
 description: |
@@ -97,16 +97,16 @@ parts:
       make download-linux
       if [ $SNAPCRAFT_ARCH_TRIPLET = "i386-linux-gnu" ]
       then
-        make -j8 HOST=i686-linux-gnu
+        make HOST=i686-linux-gnu
       elif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
       then
         update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
         arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100
         update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
         arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
-        make -j8 HOST=$SNAPCRAFT_ARCH_TRIPLET
+        make HOST=$SNAPCRAFT_ARCH_TRIPLET
       else
-        make -j8 HOST=$SNAPCRAFT_ARCH_TRIPLET
+        make HOST=$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Configure Ion Core
       cd $SNAPCRAFT_PART_BUILD
@@ -125,7 +125,7 @@ parts:
         ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Compile Ion Core
-      make -j8 
+      make 
       # Install Ion Core
       make install prefix=$SNAPCRAFT_PART_INSTALL
       # print in log which files are installed

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,11 +89,6 @@ parts:
       git apply $SNAPCRAFT_STAGE/fix-bdb-tmp-folder.patch
       ## Patch - Fix Bug extracting sources without ownership
       sed -i 's/tar --strip-components/tar --no-same-owner --strip-components/' $SNAPCRAFT_PART_BUILD/depends/funcs.mk
-      ## make gcc-4.8  the default compiler
-      /usr/sbin/update-alternatives --install /usr/bin/gcc gcc \
-      /usr/bin/gcc-4.8 100
-      /usr/sbin/update-alternatives --install /usr/bin/g++ g++ \
-      /usr/bin/g++-4.8 100
       # Build Dependencies
       echo "START BUILDING FOR $SNAPCRAFT_ARCH_TRIPLET architecture"
       cd $SNAPCRAFT_PART_BUILD/depends
@@ -102,9 +97,9 @@ parts:
       make download-linux
       if [ $SNAPCRAFT_ARCH_TRIPLET = "i386-linux-gnu" ]
       then
-        make HOST=i686-linux-gnu
+        make -j10 HOST=i686-linux-gnu
       else
-        make HOST=$SNAPCRAFT_ARCH_TRIPLET
+        make -j10 HOST=$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Configure Ion Core
       cd $SNAPCRAFT_PART_BUILD
@@ -112,11 +107,19 @@ parts:
       if [ $SNAPCRAFT_ARCH_TRIPLET = "i386-linux-gnu" ]
       then
         ./configure --prefix=`pwd`/depends/i686-linux-gnu
+      elsif [ $SNAPCRAFT_ARCH_TRIPLET = "arm-linux-gnueabihf" ]
+      then
+        apt install arm-linux-gnueabihf-gcc-4.8 arm-linux-gnueabihf-g++-4.8
+        /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc \
+        arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-4.8 100\
+        /usr/sbin/update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ \
+        arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-4.8 100
+        ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       else
         ./configure --prefix=`pwd`/depends/$SNAPCRAFT_ARCH_TRIPLET
       fi
       # Compile Ion Core
-      make
+      make -j10
       # Install Ion Core
       make install prefix=$SNAPCRAFT_PART_INSTALL
       # print in log which files are installed
@@ -125,8 +128,8 @@ parts:
     build-packages:
       - curl
       - wget
-      - gcc-4.8
-      - g++-4.8
+      - gcc
+      - g++
       - make
       - autoconf
       - automake


### PR DESCRIPTION
Have added gXX-4.8 to snapcraft.yaml for arm32 builds only to address issue #115 .  The other architectures still build with gXX-5.
