### PR TITLE
Update the tokeninfo command

### DIFF
--- a/src/consensus/tokengroups.h
+++ b/src/consensus/tokengroups.h
@@ -102,7 +102,7 @@ public:
     //* returns the parent group if this is a subgroup or itself.
     CTokenGroupID parentGroup(void) const;
     //* returns the data field of a subgroup
-    std::vector<unsigned char> GetSubGroupData();
+    const std::vector<unsigned char> &GetSubGroupData() const;
 
     const std::vector<unsigned char> &bytes(void) const { return data; }
 
@@ -319,6 +319,7 @@ bool IsOutputGroupedAuthority(const CTxOut &txout);
 bool IsAnyOutputGrouped(const CTransaction &tx);
 bool IsAnyOutputGroupedAuthority(const CTransaction &tx);
 bool IsAnyOutputGroupedCreation(const CTransaction &tx, const TokenGroupIdFlags tokenGroupIdFlags = TokenGroupIdFlags::NONE);
+bool GetGroupedCreationOutput(const CTransaction &tx, CTxOut &creationOutput, const TokenGroupIdFlags = TokenGroupIdFlags::NONE);
 
 bool AnyInputsGrouped(const CTransaction &transaction, const CCoinsViewCache& view, const CTokenGroupID tgID);
 


### PR DESCRIPTION
Update the tokeninfo command

- Add the group creation address, which receives the intial token authorities
- Move the translation of creation data into JSON to a separate function
- Separate 'regular' token data and 'extended' token data. Extended token data include the initial transaction ID and group creation address.

The group creation address is used to sign and verify the token description document.