### PR TITLE
Correct spelling of the app name in the Mac plist file

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -29,10 +29,10 @@
   <string>????</string>
 
   <key>CFBundleExecutable</key>
-  <string>Ion-Qt</string>
-  
+  <string>ION-Qt</string>
+
   <key>CFBundleName</key>
-  <string>Ion-Qt</string>
+  <string>ION-Qt</string>
 
   <key>LSHasLocalizedDisplayName</key>
   <true/>


### PR DESCRIPTION
Fixes the broken `.app` Mac executables.