### PR TITLE
Harmonize RPC call output related to tokens

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -107,9 +107,9 @@ void TokenTxnoutToUniv(const CTxOut& txout,
     } else if (!tokenGroupInfo.invalid && tokenGroupInfo.associatedGroup != NoGroup) {
         if (tokenGroupInfo.associatedGroup.isSubgroup()) {
             CTokenGroupID parentgrp = tokenGroupInfo.associatedGroup.parentGroup();
-            out.pushKV("parentGroupIdentifier", EncodeTokenGroup(parentgrp));
+            out.pushKV("parentGroupID", EncodeTokenGroup(parentgrp));
         }
-        out.pushKV("groupIdentifier", EncodeTokenGroup(tokenGroupInfo.associatedGroup));
+        out.pushKV("groupID", EncodeTokenGroup(tokenGroupInfo.associatedGroup));
         if (tokenGroupInfo.isAuthority()){
             out.pushKV("outputType", "authority");
             out.pushKV("authorities", EncodeGroupAuthority(tokenGroupInfo.controllingGroupFlags()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1951,8 +1951,8 @@ UniValue scantokens(const UniValue& params, bool fHelp)
             "    \"vout\" : n,                 (numeric) the vout value\n"
             "    \"address\" : \"address\",      (string) the address that received the tokens\n"
             "    \"scriptPubKey\" : \"script\",  (string) the script key\n"
-            "    \"ION_amount\" : x.xxx,       (numeric) The total amount in ION of the unspent output\n"
-            "    \"token_amount\" : xxx,       (numeric) The total token amount of the unspent output\n"
+            "    \"amount\" : x.xxx,       (numeric) The total amount in ION of the unspent output\n"
+            "    \"tokenAmount\" : xxx,       (numeric) The total token amount of the unspent output\n"
             "    \"height\" : n,               (numeric) Height of the unspent transaction output\n"
             "   }\n"
             "   ,...], \n"
@@ -2035,11 +2035,11 @@ UniValue scantokens(const UniValue& params, bool fHelp)
                 unspent.push_back(Pair("address", EncodeDestination(dest)));
             }
             unspent.pushKV("scriptPubKey", HexStr(txo.scriptPubKey.begin(), txo.scriptPubKey.end()));
-            unspent.pushKV("ION_amount", ValueFromAmount(txo.nValue));
+            unspent.pushKV("amount", ValueFromAmount(txo.nValue));
             if (tokenGroupInfo.isAuthority()){
-                unspent.pushKV("token_authorities", EncodeGroupAuthority(tokenGroupInfo.controllingGroupFlags()));
+                unspent.pushKV("groupAuthorities", EncodeGroupAuthority(tokenGroupInfo.controllingGroupFlags()));
             } else {
-                unspent.pushKV("token_amount", tokenGroupManager->TokenValueFromAmount(tokenGroupInfo.getAmount(), needle));
+                unspent.pushKV("tokenAmount", tokenGroupManager->TokenValueFromAmount(tokenGroupInfo.getAmount(), needle));
             }
             unspent.pushKV("height", (int32_t)coin.nHeight);
 
@@ -2047,8 +2047,8 @@ UniValue scantokens(const UniValue& params, bool fHelp)
         }
 
         result.pushKV("unspents", unspents);
-        result.pushKV("total_amount", tokenGroupManager->TokenValueFromAmount(total_in, needle));
-        result.pushKV("token_authorities", EncodeGroupAuthority(total_authorities));
+        result.pushKV("total_tokenAmount", tokenGroupManager->TokenValueFromAmount(total_in, needle));
+        result.pushKV("total_groupAuthorities", EncodeGroupAuthority(total_authorities));
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
     }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -165,11 +165,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"getchecksumblock", 1},
         {"getchecksumblock", 2},
         {"enableautomintaddress", 0},
+        {"listtokentransactions", 1},
         {"listtokentransactions", 2},
         {"listtokentransactions", 3},
-        {"listtokentransactions", 4},
-        {"listtokenssinceblock", 1},
-        {"listtokenssinceblock", 2},
     };
 
 class CRPCConvertTable

--- a/src/tokens/rpctokens.cpp
+++ b/src/tokens/rpctokens.cpp
@@ -461,12 +461,7 @@ extern UniValue tokeninfo(const UniValue &params, bool fHelp)
         }
         UniValue entry(UniValue::VOBJ);
         CTokenGroupCreation tgCreation;
-        if (grpID.isSubgroup()) {
-            CTokenGroupID parentgrp = grpID.parentGroup();
-            tokenGroupManager->GetTokenGroupCreation(parentgrp, tgCreation);
-        } else {
-            tokenGroupManager->GetTokenGroupCreation(grpID, tgCreation);
-        }
+        tokenGroupManager->GetTokenGroupCreation(grpID, tgCreation);
         TokenGroupCreationToJSON(grpID, tgCreation, entry, extended);
         ret.push_back(entry);
     } else if (operation == "ticker") {
@@ -1635,12 +1630,7 @@ extern UniValue listtokenauthorities(const UniValue &params, bool fHelp)
         ExtractDestination(coin.GetScriptPubKey(), dest);
 
         CTokenGroupCreation tgCreation;
-        if (tgInfo.associatedGroup.isSubgroup()) {
-            CTokenGroupID parentgrp = tgInfo.associatedGroup.parentGroup();
-            tokenGroupManager->GetTokenGroupCreation(parentgrp, tgCreation);
-        } else {
-            tokenGroupManager->GetTokenGroupCreation(tgInfo.associatedGroup, tgCreation);
-        }
+        tokenGroupManager->GetTokenGroupCreation(tgInfo.associatedGroup, tgCreation);
 
         UniValue retobj(UniValue::VOBJ);
         retobj.push_back(Pair("groupIdentifier", EncodeTokenGroup(tgInfo.associatedGroup)));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -19,6 +19,7 @@
 #include "utilmoneystr.h"
 #include "wallet.h"
 #include "walletdb.h"
+#include "tokens/tokengroupmanager.h"
 #include "tokens/tokengroupwallet.h"
 #include "xionchain.h"
 
@@ -1345,8 +1346,11 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
             entry.push_back(Pair("category", (it != wtx.mapValue.end() && it->second == "1") ? "darksent" : "send"));
             if (s.grp != NoGroup)
             {
-                entry.push_back(Pair("group", EncodeTokenGroup(s.grp)));
-                entry.push_back(Pair("groupAmount", -s.grpAmount));
+                CTokenGroupCreation tgCreation;
+                tokenGroupManager->GetTokenGroupCreation(s.grp, tgCreation);
+
+                entry.push_back(Pair("groupID", EncodeTokenGroup(s.grp)));
+                entry.push_back(Pair("tokenAmount", tokenGroupManager->TokenValueFromAmount(-s.amount, tgCreation.tokenGroupInfo.associatedGroup)));
             }
             entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
             entry.push_back(Pair("vout", s.vout));
@@ -1381,8 +1385,11 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
                 }
                 if (r.grp != NoGroup)
                 {
-                    entry.push_back(Pair("group", EncodeTokenGroup(r.grp)));
-                    entry.push_back(Pair("groupAmount", r.grpAmount));
+                    CTokenGroupCreation tgCreation;
+                    tokenGroupManager->GetTokenGroupCreation(r.grp, tgCreation);
+
+                    entry.push_back(Pair("groupID", EncodeTokenGroup(r.grp)));
+                    entry.push_back(Pair("tokenAmount", tokenGroupManager->TokenValueFromAmount(r.amount, tgCreation.tokenGroupInfo.associatedGroup)));
                 }
                 entry.push_back(Pair("amount", ValueFromAmount(r.amount)));
                 entry.push_back(Pair("vout", r.vout));


### PR DESCRIPTION
Harmonize ATP RPC call output naming conventions

- Token amounts are converted from their sat values to the true token values (in line with how ION values are converted from sat values to ION values)
- Token group identifiers are written as 'groupID' (instead of groupIdentifier or group)
- Similarly, parent group identifiers are written as ṕarentGroupID (instead of parentGroupIdentifier)
- ION amounts are always written as 'amount' (instead of ION_amount)
- Token amounts are always written as 'tokenAmount' (instead of token_amount). 
- Authorites are written as 'groupAuthorities' (instead of token_authorities), since the authorities operate at token group level
- Subgroup data is referred to as 'subgroupData' (instead of 'subgroup-data')

Also minor refactoring and cleanup.